### PR TITLE
Add LineAt(int index)/ElementAt(int index) and Last() methods

### DIFF
--- a/FileParserSolution/FileParser/Implementations/ParsedFile.cs
+++ b/FileParserSolution/FileParser/Implementations/ParsedFile.cs
@@ -56,6 +56,8 @@ namespace FileParser
                 : throw new ParsingException("End of ParsedFile reached");
         }
 
+        public IParsedLine LineAt(int index) => this.ElementAt(index);
+
         public IParsedLine PeekNextLine()
         {
             return !Empty
@@ -101,6 +103,8 @@ namespace FileParser
 
             return stringBuilder.ToString();
         }
+
+        public void Append(IParsedLine parsedLine) => Enqueue(parsedLine);
 
         #region Private methods
 

--- a/FileParserSolution/FileParser/Implementations/ParsedFile.cs
+++ b/FileParserSolution/FileParser/Implementations/ParsedFile.cs
@@ -56,13 +56,21 @@ namespace FileParser
                 : throw new ParsingException("End of ParsedFile reached");
         }
 
-        public IParsedLine LineAt(int index) => this.ElementAt(index);
-
         public IParsedLine PeekNextLine()
         {
             return !Empty
                 ? Peek()
                 : throw new ParsingException("End of ParsedFile reached");
+        }
+
+        public IParsedLine LineAt(int index)
+        {
+            return this.ElementAt(index);
+        }
+
+        public IParsedLine LastLine()
+        {
+            return this.Last();
         }
 
         public List<T> ToList<T>(string lineSeparatorToAdd = null)

--- a/FileParserSolution/FileParser/Implementations/ParsedFile.cs
+++ b/FileParserSolution/FileParser/Implementations/ParsedFile.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Print = System.Diagnostics.Debug;
 
 namespace FileParser
@@ -84,21 +85,21 @@ namespace FileParser
 
         public string ToSingleString(string wordSeparator = " ", string lineSeparator = null)
         {
-            string lastingString = string.Empty;
+            StringBuilder stringBuilder = new StringBuilder();
 
             while (!Empty)
             {
-                lastingString += NextLine().ToSingleString(wordSeparator);
+                stringBuilder.Append(NextLine().ToSingleString(wordSeparator));
 
                 if (!Empty)
                 {
-                    lastingString += (!string.IsNullOrEmpty(lineSeparator)
+                    stringBuilder.Append(!string.IsNullOrEmpty(lineSeparator)
                         ? lineSeparator
                         : wordSeparator);
                 }
             }
 
-            return lastingString;
+            return stringBuilder.ToString();
         }
 
         #region Private methods

--- a/FileParserSolution/FileParser/Implementations/ParsedLine.cs
+++ b/FileParserSolution/FileParser/Implementations/ParsedLine.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace FileParser
 {
@@ -57,18 +58,18 @@ namespace FileParser
 
         public string ToSingleString(string wordSeparator = " ")
         {
-            string lastingString = string.Empty;
+            StringBuilder stringBuilder = new StringBuilder();
 
             while (!Empty)
             {
-                lastingString += NextElement<string>();
+                stringBuilder.Append(NextElement<string>());
                 if (!Empty)
                 {
-                    lastingString += wordSeparator;
+                    stringBuilder.Append(wordSeparator);
                 }
             }
 
-            return lastingString;
+            return stringBuilder.ToString();
         }
 
         #region Private methods

--- a/FileParserSolution/FileParser/Implementations/ParsedLine.cs
+++ b/FileParserSolution/FileParser/Implementations/ParsedLine.cs
@@ -44,6 +44,15 @@ namespace FileParser
                 : throw new ParsingException("End of ParsedLine reached");
         }
 
+        public T ElementAt<T>(int index)
+        {
+            ValidateSupportedType<T>();
+
+            string element = this.ElementAt(index);
+
+            return StringConverter.Convert<T>(element);
+        }
+
         public List<T> ToList<T>()
         {
             List<T> list = new List<T>();
@@ -83,10 +92,7 @@ namespace FileParser
         /// <returns></returns>
         private T Extract<T>()
         {
-            if (!SupportedTypes.Contains(typeof(T)))
-            {
-                throw new NotSupportedException("Parsing to " + typeof(T).ToString() + " is not suppoerted yet");
-            }
+            ValidateSupportedType<T>();
 
             string stringToConvert = Dequeue();
 
@@ -99,7 +105,7 @@ namespace FileParser
                 if (this.Any())
                 {
                     throw new NotSupportedException("Extract<char> can only be used with one-length Queues" +
-                       " Try using ExtractChar<string> instead, after parsing each string with Extract<string>(Queue<string>)");
+                       " Try using ExtractChar<string> instead, after parsing each string with Extract<string>()");
                 }
 
                 char nextChar = ExtractChar(ref stringToConvert);
@@ -121,14 +127,19 @@ namespace FileParser
         /// <returns></returns>
         private T Peek<T>()
         {
-            if (!SupportedTypes.Contains(typeof(T)))
-            {
-                throw new NotSupportedException("Parsing to " + typeof(T).ToString() + "is not suppoerted yet");
-            }
+            ValidateSupportedType<T>();
 
             string stringToConvert = Peek();
 
             return StringConverter.Convert<T>(stringToConvert);
+        }
+
+        private static void ValidateSupportedType<T>()
+        {
+            if (!SupportedTypes.Contains(typeof(T)))
+            {
+                throw new NotSupportedException("Parsing to " + typeof(T).ToString() + "is not supported yet");
+            }
         }
 
         /// <summary>

--- a/FileParserSolution/FileParser/Implementations/ParsedLine.cs
+++ b/FileParserSolution/FileParser/Implementations/ParsedLine.cs
@@ -53,6 +53,15 @@ namespace FileParser
             return StringConverter.Convert<T>(element);
         }
 
+        public T LastElement<T>()
+        {
+            ValidateSupportedType<T>();
+
+            string element = this.Last();
+
+            return StringConverter.Convert<T>(element);
+        }
+
         public List<T> ToList<T>()
         {
             List<T> list = new List<T>();

--- a/FileParserSolution/FileParser/Implementations/ParsedLine.cs
+++ b/FileParserSolution/FileParser/Implementations/ParsedLine.cs
@@ -72,6 +72,8 @@ namespace FileParser
             return stringBuilder.ToString();
         }
 
+        public void Append(string str) => Enqueue(str);
+
         #region Private methods
 
         /// <summary>
@@ -146,8 +148,6 @@ namespace FileParser
 
             return nextChar;
         }
-
-        public void Append(string str) => Enqueue(str);
 
         /// <summary>
         /// Supported parsing conversions

--- a/FileParserSolution/FileParser/Interfaces/IParsedFile.cs
+++ b/FileParserSolution/FileParser/Interfaces/IParsedFile.cs
@@ -29,13 +29,21 @@ namespace FileParser
         IParsedLine PeekNextLine();
 
         /// <summary>
-        /// Returns the line at a specified index
+        /// Returns line at a specified index
         /// </summary>
         /// <param name="index">zero-based index</param>
-        /// <returns>The line at the specified position in file</returns>
-        /// <exception cref="System.ArgumentNullException">file is null</exception>
+        /// <returns>Line at the specified position in file</returns>
+        /// <exception cref="System.ArgumentNullException">File is null</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">index is less than 0 or greater than or equal to the number of lines in file</exception>
         IParsedLine LineAt(int index);
+
+        /// <summary>
+        /// Returns last line
+        /// </summary>
+        /// <returns>Last line</returns>
+        /// <exception cref="System.ArgumentNullException">File is null</exception>
+        /// <exception cref="System.InvalidOperationException">File is empty</exception>
+        IParsedLine LastLine();
 
         /// <summary>
         /// Returns remaining elements as a list

--- a/FileParserSolution/FileParser/Interfaces/IParsedFile.cs
+++ b/FileParserSolution/FileParser/Interfaces/IParsedFile.cs
@@ -24,6 +24,15 @@ namespace FileParser
         IParsedLine NextLine();
 
         /// <summary>
+        /// Returns the line at a specified index
+        /// </summary>
+        /// <param name="index">zero-based index</param>
+        /// <returns>The line at the specified position in file</returns>
+        /// <exception cref="System.ArgumentNullException">file is null</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">index is less than 0 or greater than or equal to the number of lines in file</exception>
+        IParsedLine LineAt(int index);
+
+        /// <summary>
         /// Returns next line (IParsedLine), not modifying ParsedFile
         /// </summary>
         /// <exception>
@@ -46,5 +55,11 @@ namespace FileParser
         /// <param name="lineSeparator"></param>
         /// <returns></returns>
         string ToSingleString(string wordSeparator = " ", string lineSeparator = null);
+
+        /// <summary>
+        /// Appends a line to the end of the file
+        /// </summary>
+        /// <param name="str"></param>
+        void Append(IParsedLine parsedLine);
     }
 }

--- a/FileParserSolution/FileParser/Interfaces/IParsedFile.cs
+++ b/FileParserSolution/FileParser/Interfaces/IParsedFile.cs
@@ -17,11 +17,16 @@ namespace FileParser
         /// <summary>
         /// Returns next line (IParsedLine), removing it from ParsedFile
         /// </summary>
-        /// <exception>
-        /// ParsingException if file is already empty
-        /// </exception>
-        /// <returns></returns>
+        /// <exception cref="ParsingException">File is already empty</exception>
+        /// <returns>Next line</returns>
         IParsedLine NextLine();
+
+        /// <summary>
+        /// Returns next line (IParsedLine), not modifying ParsedFile
+        /// </summary>
+        /// <exception cref="ParsingException">File is already empty</exception>
+        /// <returns>Next line</returns>
+        IParsedLine PeekNextLine();
 
         /// <summary>
         /// Returns the line at a specified index
@@ -31,15 +36,6 @@ namespace FileParser
         /// <exception cref="System.ArgumentNullException">file is null</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">index is less than 0 or greater than or equal to the number of lines in file</exception>
         IParsedLine LineAt(int index);
-
-        /// <summary>
-        /// Returns next line (IParsedLine), not modifying ParsedFile
-        /// </summary>
-        /// <exception>
-        /// ParsingException if file is already empty
-        /// </exception>
-        /// <returns></returns>
-        IParsedLine PeekNextLine();
 
         /// <summary>
         /// Returns remaining elements as a list

--- a/FileParserSolution/FileParser/Interfaces/IParsedLine.cs
+++ b/FileParserSolution/FileParser/Interfaces/IParsedLine.cs
@@ -17,21 +17,30 @@ namespace FileParser
         /// <summary>
         /// Returns next element of type T, removing it from ParsedLine
         /// </summary>
-        /// <exception>
-        /// ParsingException if line is already empty
-        /// </exception>
-        /// <returns></returns>
+        /// <exception cref="ParsingException">Line is already empty</exception>
+        /// <exception cref="System.NotSupportedException">Parsing to chosen type is not supported yet or T is char and line's length > 1</exception>
+        /// <returns>Next element</returns>
         T NextElement<T>();
 
         /// <summary>
-        /// Returns next element of type T, not modifying ParsedLine
+        /// Returns next element of type T, not modifying ParsedLine.
         /// This still allows its modification
         /// </summary>
-        /// <exception>
-        /// ParsingException if line is already empty
-        /// </exception>
-        /// <returns></returns>
+        /// <exception cref="ParsingException">Line is already empty</exception>
+        /// <exception cref="System.NotSupportedException">Parsing to chosen type is not supported yet</exception>
+        /// <returns>Next element</returns>
         T PeekNextElement<T>();
+
+        /// <summary>
+        /// Returns the element at a specified index, allowing its modification
+        /// </summary>
+        /// <param name="index">zero-based index</param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The element at the specified position in line</returns>
+        /// <exception cref="System.ArgumentNullException">file is null</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">index is less than 0 or greater than or equal to the number of lines in file</exception>
+        /// <exception cref="System.NotSupportedException">Parsing to selected type is not supported yet</exception>
+        T ElementAt<T>(int index);
 
         /// <summary>
         /// Returns remaining elements as a list

--- a/FileParserSolution/FileParser/Interfaces/IParsedLine.cs
+++ b/FileParserSolution/FileParser/Interfaces/IParsedLine.cs
@@ -32,15 +32,25 @@ namespace FileParser
         T PeekNextElement<T>();
 
         /// <summary>
-        /// Returns the element at a specified index, allowing its modification
+        /// Returns element at a specified index, allowing its modification
         /// </summary>
         /// <param name="index">zero-based index</param>
         /// <typeparam name="T"></typeparam>
-        /// <returns>The element at the specified position in line</returns>
-        /// <exception cref="System.ArgumentNullException">file is null</exception>
-        /// <exception cref="System.ArgumentOutOfRangeException">index is less than 0 or greater than or equal to the number of lines in file</exception>
+        /// <returns>Element at the specified position in line</returns>
         /// <exception cref="System.NotSupportedException">Parsing to selected type is not supported yet</exception>
+        /// <exception cref="System.ArgumentNullException">File is null</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">index is less than 0 or greater than or equal to the number of lines in file</exception>
         T ElementAt<T>(int index);
+
+        /// <summary>
+        /// Returns last element
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>Last element</returns>
+        /// <exception cref="System.NotSupportedException">Parsing to selected type is not supported yet</exception>
+        /// <exception cref="System.ArgumentNullException">Line is null</exception>
+        /// <exception cref="System.InvalidOperationException">Line is empty</exception>
+        T LastElement<T>();
 
         /// <summary>
         /// Returns remaining elements as a list

--- a/FileParserSolution/FileParser/ParsingException.cs
+++ b/FileParserSolution/FileParser/ParsingException.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace FileParser
 {
+    [Serializable]
     public class ParsingException : Exception
     {
         private const string _genericMessage = "Exception triggered during parsing process";
@@ -15,6 +17,10 @@ namespace FileParser
         }
 
         public ParsingException(string message, Exception inner) : base(message ?? _genericMessage, inner)
+        {
+        }
+
+        protected ParsingException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/FileParserSolution/FileParserTest/ParsedFileTest/GeneralTests.cs
+++ b/FileParserSolution/FileParserTest/ParsedFileTest/GeneralTests.cs
@@ -137,5 +137,50 @@ namespace FileParserTest.ParsedFileTest
             IParsedFile file = new ParsedFile(_sampleFolderPath + "FileWithEmtpyLines.txt");
             Assert.True(file.Count == 5);
         }
+
+        [Fact]
+        public void LineAt()
+        {
+            IParsedFile file = new ParsedFile(_sampleFolderPath + "Sample_file.txt");
+
+            IParsedLine lineAt0 = file.LineAt(0);
+
+            int n = lineAt0.PeekNextElement<int>();
+            Assert.Equal(23, n);
+            string nPlusOne = (n + 1).ToString();
+            lineAt0.Append($" {nPlusOne}");
+
+            file.Append(new ParsedLine(new[] { nPlusOne }));
+            int totalNumberOfLines = file.Count;
+
+            IParsedLine firstLine = file.NextLine();
+            int nAgain = firstLine.NextElement<int>();
+            string str = firstLine.NextElement<string>();
+            int incrementedN = firstLine.NextElement<int>();
+            Assert.Equal(n, nAgain);
+            Assert.Equal(n + 1, incrementedN);
+            Assert.Equal("food", str);
+
+            for (int lineIndex = 1; lineIndex < totalNumberOfLines - 1; ++lineIndex)
+            {
+                IParsedLine line = file.NextLine();
+                int counter = line.NextElement<int>();
+                for (int j = 0; j < counter; ++j)
+                {
+                    line.NextElement<int>();
+                }
+
+                while (!line.Empty)
+                {
+                    line.NextElement<string>();
+                }
+            }
+
+            Assert.False(file.Empty);
+            IParsedLine lastLine = file.NextLine();
+            Assert.Equal(incrementedN, lastLine.NextElement<int>());
+            Assert.True(lastLine.Empty);
+            Assert.True(file.Empty);
+        }
     }
 }

--- a/FileParserSolution/FileParserTest/ParsedFileTest/GeneralTests.cs
+++ b/FileParserSolution/FileParserTest/ParsedFileTest/GeneralTests.cs
@@ -1,4 +1,5 @@
 ﻿using FileParser;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -161,6 +162,9 @@ namespace FileParserTest.ParsedFileTest
             Assert.Equal(nPlusOne, incrementedN);
             Assert.Equal("food", str);
 
+            IParsedLine lastLine = file.LastLine();
+            Assert.Equal(incrementedN, lastLine.PeekNextElement<int>());
+
             for (int lineIndex = 1; lineIndex < totalNumberOfLines - 1; ++lineIndex)
             {
                 IParsedLine line = file.NextLine();
@@ -176,11 +180,14 @@ namespace FileParserTest.ParsedFileTest
                 }
             }
 
-            Assert.False(file.Empty);
-            IParsedLine lastLine = file.NextLine();
-            Assert.Equal(incrementedN, lastLine.NextElement<int>());
-            Assert.True(lastLine.Empty);
+            IParsedLine extraLine = file.NextLine();
+            Assert.Equal(incrementedN, extraLine.NextElement<int>());
+            Assert.True(extraLine.Empty);
+            Assert.Throws<ArgumentOutOfRangeException>(() => extraLine.ElementAt<string>(1));
+            Assert.Throws<InvalidOperationException>(() => extraLine.LastElement<string>());
             Assert.True(file.Empty);
+            Assert.Throws<ArgumentOutOfRangeException>(() => file.LineAt(1));
+            Assert.Throws<InvalidOperationException>(() => file.LastLine());
         }
     }
 }

--- a/FileParserSolution/FileParserTest/ParsedFileTest/GeneralTests.cs
+++ b/FileParserSolution/FileParserTest/ParsedFileTest/GeneralTests.cs
@@ -147,10 +147,10 @@ namespace FileParserTest.ParsedFileTest
 
             int n = lineAt0.PeekNextElement<int>();
             Assert.Equal(23, n);
-            string nPlusOne = (n + 1).ToString();
+            int nPlusOne = n + 1;
             lineAt0.Append($" {nPlusOne}");
 
-            file.Append(new ParsedLine(new[] { nPlusOne }));
+            file.Append(new ParsedLine(new[] { nPlusOne.ToString() }));
             int totalNumberOfLines = file.Count;
 
             IParsedLine firstLine = file.NextLine();
@@ -158,7 +158,7 @@ namespace FileParserTest.ParsedFileTest
             string str = firstLine.NextElement<string>();
             int incrementedN = firstLine.NextElement<int>();
             Assert.Equal(n, nAgain);
-            Assert.Equal(n + 1, incrementedN);
+            Assert.Equal(nPlusOne, incrementedN);
             Assert.Equal("food", str);
 
             for (int lineIndex = 1; lineIndex < totalNumberOfLines - 1; ++lineIndex)

--- a/FileParserSolution/FileParserTest/ParsedLineTest/ElementAtTest.cs
+++ b/FileParserSolution/FileParserTest/ParsedLineTest/ElementAtTest.cs
@@ -1,0 +1,35 @@
+﻿using FileParser;
+using System;
+using System.IO;
+using Xunit;
+
+namespace FileParserTest.ParsedLineTest
+{
+    public class ElementAtTest
+    {
+        private readonly string _sampleFolderPath = "TestFiles" + Path.DirectorySeparatorChar;
+
+        [Fact]
+        public void ElementAt()
+        {
+            IParsedFile file = new ParsedFile(_sampleFolderPath + "Sample_file.txt");
+
+            IParsedLine firstLine = file.NextLine();
+            string lastElement = firstLine.ElementAt<string>(firstLine.Count - 1);
+            Assert.Equal("food", lastElement);
+
+            IParsedLine peekedSecondLine = file.PeekNextLine();
+            int number = peekedSecondLine.ElementAt<int>(1);
+            Assert.Equal(100, number);
+            const double modifiedNumber = 100 + Math.PI;
+            peekedSecondLine.Append($" {modifiedNumber}");
+
+            IParsedLine secondLine = file.NextLine();
+            int numberAgain = secondLine.ElementAt<int>(1);
+            Assert.Equal(number, numberAgain);
+
+            double addedNumber = secondLine.ElementAt<double>(secondLine.Count - 1);
+            Assert.Equal(modifiedNumber, addedNumber, 10);
+        }
+    }
+}


### PR DESCRIPTION
Main changes:
* Add `IParsedLine IParsedFile.LineAt(int)` and  `IParsedLine IParsedFile.LastLine()`.
* Add `T IParsedLine.ElementAt(int)` and  `T IParsedLine.LastElement<T>()`.

Minor modifications:
* Use `StringBuilder` in `ToSingleString()` methods.
* Make `ParsingException` serializable.
* Improve documentation by adding thrown exceptions to public methods XML comments.