### PR TITLE
Fix cron expression for scheduled jobs in GitHub actions

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -8,7 +8,7 @@ on:
     branches:
     - master
   schedule:
-    - cron:  '* * * * 1'
+    - cron:  '1 0 * * 1'
     # * is a special character in YAML so you have to quote this string
 
 jobs:


### PR DESCRIPTION
Fix cron expression for scheduled jobs, so that they don't run 'at every minute on Monday' but every Monday at 00:01am.
😭 