### PR TITLE
Drop .NET Framework 4.6 and :construction_worker: improvements

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1.4.0
       with:
-        dotnet-version: 3.1.102
+        dotnet-version: 3.1.300
     - name: Give permissions to CI scripts
       run: chmod -R 777 ./ci/
     - name: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,7 @@ schedules:
 variables:
   Agent: 'windows-2019'
   BuildConfiguration: 'Release'   # configuration to pack, does not work with build step
+  SdkVersion: '3.1.x'
 
 stages:
 - stage: CI
@@ -26,6 +27,12 @@ stages:
     pool:
       vmImage: $(Agent)
     steps:
+
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core sdk v$(SdkVersion)'
+      inputs:
+        packageType: sdk
+        version: '$(SdkVersion)'
 
     - task: SonarCloudPrepare@1
       inputs:
@@ -60,7 +67,7 @@ stages:
 - stage: CD
   displayName: 'Generate package(s)'
   dependsOn: 'CI'
-  condition: and(succeeded('CI'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['PackageVersion'], ''))
+  condition: and(succeeded('CI'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
   jobs:
   - job: cd
     displayName: 'Generate package(s)'
@@ -71,6 +78,12 @@ stages:
     - checkout: self
       persistCredentials: true
       clean: true
+
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core sdk v$(SdkVersion)'
+      inputs:
+        packageType: sdk
+        version: '$(SdkVersion)'
 
     - task: NuGetToolInstaller@1
       displayName: 'Setup NuGet'
@@ -90,11 +103,12 @@ stages:
       displayName: 'Build'
       inputs:
         command: build
-        arguments: '--configuration Release'
+        arguments: '--configuration Release /p:ContinuousIntegrationBuild=true'
         projects: './src/FileParserSolution.sln'
 
     - task: DotNetCoreCLI@2
       displayName: 'Modify project version'
+      condition: ne(variables['PackageVersion'], '')
       inputs:
         command: build
         arguments: '--configuration Release /t:ReplaceVersion /p:VersionTag=$(PackageVersion)'
@@ -127,6 +141,7 @@ stages:
 
     - task: NuGetCommand@2
       displayName: 'Push NuGet package'
+      condition: ne(variables['PackageVersion'], '')
       inputs:
         command: 'push'
         packagesToPush: '$(Build.SourcesDirectory)/Artifacts/*.nupkg'
@@ -136,6 +151,7 @@ stages:
 
     - task: NuGetCommand@2
       displayName: 'Push GitHub package'
+      condition: ne(variables['PackageVersion'], '')
       inputs:
         command: 'push'
         packagesToPush: '$(Build.SourcesDirectory)/Artifacts/*.nupkg'
@@ -145,6 +161,7 @@ stages:
 
     - task: CmdLine@2
       displayName: 'Commit and push version increment'
+      condition: and(eq(variables['NoCommit'], ''), ne(variables['PackageVersion'], ''))
       inputs:
         workingDirectory: $(Build.SourcesDirectory)
         script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,6 +41,7 @@ stages:
       TestResults: '$(Agent.TempDirectory)'
       CoverageResults: '$(Build.SourcesDirectory)/CoverageResults'
 
+    steps:
     - task: UseDotNet@2
       displayName: 'Use .NET Core sdk v$(SdkVersion)'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,6 @@ schedules:
     - master
 
 variables:
-  Agent: 'windows-2019'
-  BuildConfiguration: 'Release'   # configuration to pack, does not work with build step
   SdkVersion: '3.1.x'
 
 stages:
@@ -24,9 +22,24 @@ stages:
   jobs:
   - job: ci
     displayName: 'Build and run tests'
+
+    strategy:
+      maxParallel: 3
+      matrix:
+        linux:
+          imageName: 'ubuntu-latest'
+        mac:
+          imageName: 'macOS-latest'
+        windows:
+          imageName: 'windows-latest'
     pool:
-      vmImage: $(Agent)
-    steps:
+      vmImage: $(imageName)
+
+    variables:
+      disable.coverage.autogenerate: 'true'
+      EscapedComma: '%2c'
+      TestResults: '$(Agent.TempDirectory)'
+      CoverageResults: '$(Build.SourcesDirectory)/CoverageResults'
 
     - task: UseDotNet@2
       displayName: 'Use .NET Core sdk v$(SdkVersion)'
@@ -35,12 +48,17 @@ stages:
         version: '$(SdkVersion)'
 
     - task: SonarCloudPrepare@1
+      displayName: 'Prepare SonarCloud analysis'
+      condition: eq(variables['imageName'], 'windows-latest')
       inputs:
         SonarCloud: 'FileParser_SonarCloud'
         organization: 'eduherminio-github'
         scannerMode: 'MSBuild'
         projectKey: 'FileParser'
         projectName: 'FileParser'
+        extraProperties: |
+            sonar.cs.opencover.reportsPaths="$(Build.SourcesDirectory)/**/coverage.opencover.xml"
+            sonar.cs.vstest.reportsPaths="$(TestResults)/**/*.trx"
 
     - task: DotNetCoreCLI@2
       displayName: 'Build'
@@ -53,14 +71,39 @@ stages:
       displayName: 'Run tests'
       inputs:
         command: test
-        arguments: '--configuration Release --no-build --logger trx --collect "Code coverage"'
+        arguments: >-
+            --configuration Release --no-build
+            /p:CollectCoverage=true /p:CoverletOutputFormat="cobertura$(EscapedComma)opencover"
+            /p:CoverletOutput=./CoverageResults/ /p:ExcludeByFile="**/*Exceptions.cs$(EscapedComma)**/*Test.cs"
         nobuild: true
         projects: '**/FileParser.Test.csproj'
         publishTestResults: true
 
+    - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
+      displayName: 'Generate tests report'
+      condition: eq(variables['imageName'], 'ubuntu-latest')
+      inputs:
+        reports: '$(Build.SourcesDirectory)/**/coverage.cobertura.xml'
+        targetdir: '$(CoverageResults)'
+        reporttypes: 'HtmlInline_AzurePipelines;Cobertura;Badges'
+        assemblyfilters: '-xunit*'
+
+    - task: PublishCodeCoverageResults@1
+      displayName: 'Publish code coverage'
+      condition: eq(variables['imageName'], 'ubuntu-latest')
+      inputs:
+        codeCoverageTool: Cobertura
+        summaryFileLocation: '$(CoverageResults)/Cobertura.xml'
+        reportDirectory: '$(CoverageResults)'
+        pathToSources: '$(Build.SourcesDirectory)'
+
     - task: SonarCloudAnalyze@1
+      displayName: 'Perform SonarCloud analysis'
+      condition: eq(variables['imageName'], 'windows-latest')
 
     - task: SonarCloudPublish@1
+      displayName: 'Publish SonarCloud analysis'
+      condition: eq(variables['imageName'], 'windows-latest')
       inputs:
         pollingTimeoutSec: '300'
 
@@ -72,7 +115,7 @@ stages:
   - job: cd
     displayName: 'Generate package(s)'
     pool:
-      vmImage: $(Agent)
+      vmImage: ubuntu-latest
     steps:
 
     - checkout: self
@@ -119,11 +162,10 @@ stages:
       inputs:
         command: 'pack'
         arguments: '--configuration Release'
-        configuration: '$(BuildConfiguration)'
+        configuration: 'Release'
         packagesToPack: '**/FileParser.csproj'
         nobuild: true
         packDirectory: '$(Build.SourcesDirectory)/Artifacts'
-        versioningScheme: 'off'     # We're using ReplaceVersion target instead
 
     - task: PublishBuildArtifacts@1
       displayName: 'Publish artifact with NuGet package and its symbols'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,7 +75,7 @@ stages:
         arguments: >-
             --configuration Release --no-build
             /p:CollectCoverage=true /p:CoverletOutputFormat="cobertura$(EscapedComma)opencover"
-            /p:CoverletOutput=./CoverageResults/ /p:ExcludeByFile="**/*Exceptions.cs$(EscapedComma)**/*Test.cs"
+            /p:CoverletOutput=./CoverageResults/ /p:ExcludeByFile="**/*Exception.cs$(EscapedComma)**/*Test.cs"
         nobuild: true
         projects: '**/FileParser.Test.csproj'
         publishTestResults: true

--- a/ci/build.bat
+++ b/ci/build.bat
@@ -1,1 +1,1 @@
-dotnet build ./src/FileParser --configuration Release --force --no-incremental --framework netstandard2.1
+dotnet build ./src/FileParser --configuration Release --force --no-incremental

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -6,7 +6,7 @@
 set -e
 
 dotnet restore ./src
-dotnet build ./src/FileParser --configuration Release --force --no-incremental --framework netstandard2.1
+dotnet build ./src/FileParser --configuration Release --force --no-incremental
 
 revision=${TRAVIS_JOB_ID:=1}
 revision=$(printf "%04d" $revision)

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -5,7 +5,7 @@
 # exit if any command fails
 set -e
 
-dotnet test ./src/FileParser.Test --logger trx --collect "Code coverage;XPlat Code coverage"
+dotnet test ./src/FileParser.Test --logger trx --collect "Code coverage"
 
 revision=${TRAVIS_JOB_ID:=1}
 revision=$(printf "%04d" $revision)

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -5,7 +5,7 @@
 # exit if any command fails
 set -e
 
-dotnet test ./src/FileParser.Test --framework=netcoreapp3.1 --logger trx --collect "Code coverage"
+dotnet test ./src/FileParser.Test --logger trx --collect "Code coverage;XPlat Code coverage"
 
 revision=${TRAVIS_JOB_ID:=1}
 revision=$(printf "%04d" $revision)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+  </ItemGroup>
+
+</Project>

--- a/src/FileParser.Test/FileParser.Test.csproj
+++ b/src/FileParser.Test/FileParser.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.2;net471;net461;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/FileParser.Test/FileParser.Test.csproj
+++ b/src/FileParser.Test/FileParser.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/FileParser.Test/FileParser.Test.csproj
+++ b/src/FileParser.Test/FileParser.Test.csproj
@@ -8,8 +8,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="All"/>
+    <PackageReference Include="coverlet.collector" Version="1.2.1" PrivateAssets="All"/>
+    <PackageReference Include="coverlet.msbuild" Version="2.8.1" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FileParser/FileParser.csproj
+++ b/src/FileParser/FileParser.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Title>FileParser</Title>

--- a/src/FileParser/FileParser.csproj
+++ b/src/FileParser/FileParser.csproj
@@ -17,6 +17,7 @@
     <RepositoryUrl>https://github.com/eduherminio/FileParser</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -26,9 +27,5 @@
 
   <Import Project="FileParser.targets" />
   <Import Project="FileParser.tasks" />
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-  </ItemGroup>
 
 </Project>

--- a/src/FileParserSolution.sln
+++ b/src/FileParserSolution.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\ci\build.bat = ..\ci\build.bat
 		..\ci\build.sh = ..\ci\build.sh
 		..\.circleci\config.yml = ..\.circleci\config.yml
+		Directory.Build.props = Directory.Build.props
 		..\.github\workflows\github-actions.yml = ..\.github\workflows\github-actions.yml
 		..\ci\test.bat = ..\ci\test.bat
 		..\ci\test.sh = ..\ci\test.sh


### PR DESCRIPTION
* Drop support for .NET Framework 4.6.
* Turn green NuGet package's health.
* Bump .NET Core sdk to 3.1.300.
* Use UseDotNet@2 task.
* Allow CD stage to always run on master, even if `PackageVersion` is null; but preventing package push and commits in that case.