### PR TITLE
Add BuiltWithDot.Net badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 [![API][apimundologo]][apimundolink]
 
+[![BuiltWithDot.Net shield](https://builtwithdot.net/project/446/file-parser/badge)](https://builtwithdot.net/project/446/file-parser)
+
 **FileParser** is a **.NET** library designed to read text files line-by-line, saving each line's content into basic types vars (int, double, string, etc.).
 
 - .NET Framework 4.6 was supported until v1.4.x.


### PR DESCRIPTION
Since FileParser is listed on BuiltWithDot.Net I've taken the liberty to raise a PR that adds the BuiltWithDot.Net badge for FileParser to the README.md file. This will help promote your project, BuiltWithDot.Net, all other .NET developers that have projects listed on the site, and the open-source .NET ecosystem in general. If you have any questions or concerns, please let me know. Your help is much appreciated!

Thanks, Corstiaan (creator of BuiltWithDot.Net)

PS If you don't want to add the badge, that's totally fine. Just close this PR. No hard feelings :-)